### PR TITLE
Getting size/vsize from daemon

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -91,7 +91,7 @@ TxController.prototype.transformTransaction = function(transaction, options, cal
   }
 
   transformed.valueOut = transaction.outputSatoshis / 1e8;
-  transformed.size = transaction.hex.length / 2; // in bytes
+  transformed.size = transaction.size; // can be virtual size (not equal to actual) if segwit
   if (!transaction.coinbase) {
     transformed.valueIn = transaction.inputSatoshis / 1e8;
     transformed.fees = transaction.feeSatoshis / 1e8;


### PR DESCRIPTION
This is needed for insight to display "correct" size and fee/byte for segwit transactions.

Necessary patch in litecore-node - https://github.com/litecoin-project/litecore-node/pull/3

What is displayed in the web UI as "Size" is actually "virtual size" - https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#transaction-size-calculations - what is actually used when miners are comparing fees in mempool.

It seems to me it's better than adding new "Virtual size" row to GUI, since that would be confusing, plus it needs less commits and patches :) and is backwards compatible.

Fee/byte is then calculated from this virtual size, as it should be.